### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-strict-peer-dependencies=false
-shamefully-hoist=true

--- a/package.json
+++ b/package.json
@@ -64,5 +64,5 @@
     "playwright": "1.60.0",
     "vitest": "4.1.6"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,15 @@
 packages:
   - "playground"
 
-
 overrides:
   "@nuxt/schema": "4.4.5"
   "@nuxtjs/harlem": "link:./"
+
+strictPeerDependencies: false
+
+shamefullyHoist: true
+
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: false
+  unrs-resolver: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`